### PR TITLE
chore(deps): update hashicorp/vault docker tag to v2

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,6 +1,6 @@
 services:
   vault:
-    image: "hashicorp/vault:1.21.4"
+    image: "hashicorp/vault:2.0.0"
     cap_add:
       - IPC_LOCK
     ports:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       - "8200:8200"
     environment:
       VAULT_DEV_ROOT_TOKEN_ID: "development"
+      SKIP_SETCAP: "true"
     healthcheck:
       test: ["CMD", "wget", "--spider", "--quiet", "http://127.0.0.1:8200/v1/sys/health"]
       interval: 2s


### PR DESCRIPTION
Cherry-picks #395 (bump `hashicorp/vault` to `2.0.0`) and adds the fix needed to make CI pass.

Vault 2.0 changed the image to run as the unprivileged `vault` user. The entrypoint script still tries to `setcap cap_ipc_lock=+ep` on the vault binary, which now fails with `Operation not permitted` and causes the container to exit before becoming healthy — that's what was killing CI on #395.

Setting `SKIP_SETCAP=true` skips the setcap step. mlock isn't needed for the dev-mode server we run in tests, so this is safe. Verified locally: `docker compose up -d --build --wait` brings vault up healthy and the vault loader integration tests pass.

Closes #395.